### PR TITLE
Update fpc wrapper

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,3 +104,7 @@ enjoy !!!
 
 <img align="center" src="https://raw.githubusercontent.com/GuvaCode/GuvaCode/main/ray4laz_img/powered_by.png" width="64px">
 
+
+**manual installation**
+
+clone this repository, then use 'fpc-wrapper.sh' as your compiler. this script automatically feeds fpc with the necessary arguments.

--- a/fpc-wrapper.sh
+++ b/fpc-wrapper.sh
@@ -1,20 +1,25 @@
-#!/bin/sh
+#!/usr/bin/env bash
 
 # a wrapper for fpc to automatically add enough flags
 
-get_lib_name()
-{
-	# return 64 if 64
-	if [ `uname -m` -eq "x86_64" ]
-	then
-		return "x86_64-linux"
-	else
-		return "x86_32-linux"
-	fi
-}
-PLATFORM=get_lib_name;
+set -e
+
+if [[ `command -v fpc` == "" ]]
+then
+	echo "Could not find fpc on your system."
+	exit 1
+fi
+
+HERE=$(readlink -f $(dirname $0))
+
+PLATFORM="x86_32-linux";
+
+if [[ `uname -m` -eq "x86_64" ]]
+then
+	PLATFORM="x86_64-linux"
+fi
 
 BASE_FLAGS="-MObjFPC -Scghi -Cg -l -vewnhibq"
-INCLUDE_FLAGS="-Fl./libs/$PLATFORM -Fu./source -Fu./headers"
+INCLUDE_FLAGS="-Fl$HERE/libs/$PLATFORM -Fu$HERE/source -Fu$HERE/headers"
 
 fpc $BASE_FLAGS $INCLUDE_FLAGS $*


### PR DESCRIPTION
An update to the previous commit.

Now the wrapper can be executed from anywhere, and it will find the necessary files itself.
Also now there is a strict bash shebang, as some especially Debian-based distros use the stupid "dash" as /bin/sh, and apparently dash is incompatible with bash.
Also now it detects if fpc is not present, and prints an error message.

Also added a note in the readme about manual installation.