### PR TITLE
Cleaning up ignored code after `end.`

### DIFF
--- a/examples/core/core_2d_camera_platformer/core_2d_camera_platformer.lpr
+++ b/examples/core/core_2d_camera_platformer/core_2d_camera_platformer.lpr
@@ -341,15 +341,3 @@ begin
   CloseWindow(); // Close window and OpenGL context
   //---------------------------------------------------------------------------------------------
 end.
-
-
-{ TEnvItem }
-
-{constructor TEnvItem.Create(Rect: TRectangle; Blocking: Integer; Color: TColor);
-begin
-
-end;}
-
-
-end.
-


### PR DESCRIPTION
This PR cleans up the unused code after `end.` (with a dot). It is the end of the unit, and the compiler does not read after it anyway.