### PR TITLE
Disable x11 libs on Mac in raylib.pas

### DIFF
--- a/source/raylib.pas
+++ b/source/raylib.pas
@@ -2440,7 +2440,9 @@ uses
     {$linklib m}
     {$linklib dl}
     {$linklib pthread}
-    {$linklib X11}
+    {$IFNDEF darwin}
+       {$linklib X11}
+    {$ENDIF}
   //  {$linklib libXrandr}
  //   {$linklib libXinerama}
   //  {$linklib libXi}


### PR DESCRIPTION
This fixes issue #65 by simply using IFNDEF to disable x11 libs for darwin.  