### PR TITLE
Fix macOS compilation linker options

### DIFF
--- a/README_mac_mseries.md
+++ b/README_mac_mseries.md
@@ -43,11 +43,11 @@ There are three options:
 ```
       <Options>
         <PassLinkerOptions Value="True"/>
-        <LinkerOptions Value="&apos;-framework IOKit&apos;"/>
+        <LinkerOptions Value="-framework IOKit"/>
       </Options>
     </Linking>
     <Other>
-      <CustomOptions Value="&apos;-WM11.0&apos;"/>
+      <CustomOptions Value="-WM11.0"/>
     </Other>
   </CompilerOptions>
 ```
@@ -62,11 +62,11 @@ Run these commands in the folder of the project you wish to change:
 sed -i '' '/<\/Linking>/,/<\/CompilerOptions>/c\
      <Options>\
         <PassLinkerOptions Value="True"/>\
-        <LinkerOptions Value="&apos;-framework IOKit&apos;"/>\
+        <LinkerOptions Value="-framework IOKit"/>\
       </Options>\
     </Linking>\
     <Other>\
-      <CustomOptions Value="&apos;-WM11.0&apos;"/>\
+      <CustomOptions Value="-WM11.0"/>\
     </Other>\
   </CompilerOptions>' *.lpi
 sed -i '' '/^uses/ s/^uses/& CocoaAll,/' *.lpr
@@ -81,11 +81,11 @@ Run these commands from the _root folder of the repo_ to make these changes to e
 find examples -type f -name "*.lpi" -print0 | xargs -0 sed -i '' '/<\/Linking>/,/<\/CompilerOptions>/c\
      <Options>\
         <PassLinkerOptions Value="True"/>\
-        <LinkerOptions Value="&apos;-framework IOKit&apos;"/>\
+        <LinkerOptions Value="-framework IOKit"/>\
       </Options>\
     </Linking>\
     <Other>\
-      <CustomOptions Value="&apos;-WM11.0&apos;"/>\
+      <CustomOptions Value="-WM11.0"/>\
     </Other>\
   </CompilerOptions>'
 find examples -type f -name "*.lpr" -print0 | xargs -0 sed -i '' '/^uses/ s/^\(uses\)/\1 CocoaAll,/'

--- a/package/ray4laz_customappprj.pas
+++ b/package/ray4laz_customappprj.pas
@@ -146,9 +146,9 @@ begin
   {$IFDEF DARWIN}
   Aproject.LazCompilerOptions.PassLinkerOptions := True;
   {$IFDEF CPUAARCH64}
-  AProject.LazCompilerOptions.CustomOptions:='''-WM11.0''';
+  AProject.LazCompilerOptions.CustomOptions:='-WM11.0';
   {$ENDIF}
-  AProject.LazCompilerOptions.LinkerOptions := '''-framework IOKit''';
+  AProject.LazCompilerOptions.LinkerOptions := '-framework IOKit';
   {$ENDIF}
   AProject.LazCompilerOptions.TargetFilename:= 'Project' + IntToStr(AProject.FileCount);
   AProject.AddPackageDependency('ray4laz');

--- a/package/ray4laz_simpleprj.pas
+++ b/package/ray4laz_simpleprj.pas
@@ -108,9 +108,9 @@ begin
   {$IFDEF DARWIN}
   Aproject.LazCompilerOptions.PassLinkerOptions := True;
   {$IFDEF CPUAARCH64}
-  AProject.LazCompilerOptions.CustomOptions:='''-WM11.0''';
+  AProject.LazCompilerOptions.CustomOptions:='-WM11.0';
   {$ENDIF}
-  AProject.LazCompilerOptions.LinkerOptions := '''-framework IOKit''';
+  AProject.LazCompilerOptions.LinkerOptions := '-framework IOKit';
   {$ENDIF}
   AProject.AddPackageDependency('ray4laz');
 end;


### PR DESCRIPTION
This PR fixes incorrect quoting in macOS linker options.

The issue was that the macOS specific linker options were written with extra embedded quotes, which caused invalid values to be generated in project files and templates.  This was my mistake last year.  

## Changes

- Fixed the example in `README_mac_mseries.md`
    
- Fixed the same quoting issue in:
    
    - `package/ray4laz_customappprj.pas`
        
    - `package/ray4laz_simpleprj.pas`
        
- Applied the same correction to both `-framework IOKit` and `-WM11.0`
    

## Example

**Before**

xml

`<LinkerOptions Value="&apos;-framework IOKit&apos;"/>`

text

`AProject.LazCompilerOptions.LinkerOptions := '''-framework IOKit''';`

**After**

xml

`<LinkerOptions Value="-framework IOKit"/>`

text

`AProject.LazCompilerOptions.LinkerOptions := '-framework IOKit';`

This allows the generated macOS project settings to use the intended linker flags instead of malformed quoted values